### PR TITLE
update setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description=readme,
     author='Liam Brenner',
     author_email='liam.brenner@gmail.com',
-    url='https://bitbucket.org/sablewalnut/wagtailinvoices',
+    url='https://github.com/SableWalnut/wagtailinvoices',
 
     install_requires=[
         'wagtail>=1.0',


### PR DESCRIPTION
Use current GitHub repo's URL instead of unavailable BitBucket URL.

It's a tiny thing but it breaks the link to the repo from PyPI so...

Thanks for sharing your code!